### PR TITLE
追加実装：ユーザー情報編集機能の変更

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -39,13 +39,6 @@
     <%= f.password_field :password_confirmation, class:"input-default", id:"password-confirmation", placeholder:"同じパスワードを入力して下さい" %>
   </div>
   <div class="form-group">
-    <div class='form-text-wrap'>
-      <label class="form-text">現パスワード(変更しない場合は空白)</label>
-    </div>
-    <%= f.password_field :current_password, class:"input-default", id:"current_password", placeholder:"6文字以上の半角英数字" %>
-    <p class='info-text'>※英字と数字の両方を含めて設定してください</p>
-  </div>
-  <div class="form-group">
     <p class='form-info-header'>
       本人確認
     </p>


### PR DESCRIPTION
# What
ユーザー情報編集ページのレイアウトを変更

# Why
ユーザー情報編集ページにおいて、現パスワードの入力エリアが不要となったため